### PR TITLE
fix(env_gathering): guard gs.init() with `if not gs._initialized`

### DIFF
--- a/experiments/envs/env_gathering.py
+++ b/experiments/envs/env_gathering.py
@@ -8,7 +8,8 @@ from utils.controller import RobotControllerPink
 
 class Train_Env_Gathering(Train_Env):
     def __init__(self, config):
-        gs.init(seed=0, precision="64", logging_level="error", backend=gs.gpu, performance_mode=True)
+        if not gs._initialized:
+            gs.init(seed=0, precision="64", logging_level="error", backend=gs.gpu, performance_mode=True)
         viewer_options = gs.options.ViewerOptions(
             camera_pos=(3, -1, 1.5),
             camera_lookat=(0.0, 0.0, 0.0),


### PR DESCRIPTION
## Summary

Calling `gs.init()` unconditionally in `Train_Env_Gathering.__init__` crashes
with `GenesisException: Genesis already initialized` when any other environment
has already initialized Genesis in the same process — for example, when running
tasks sequentially in a loop.

## Root cause

`env_gathering.py` constructs its own Genesis scene before calling
`super().__init__()`, and calls `gs.init()` without checking whether Genesis
is already running. Every other env delegates this to the base class
`Train_Env.__init__`, which guards the call:

```python
if not gs._initialized:
    gs.init(seed=0, precision="64", ...)
```

Gathering bypasses this guard, causing the crash.

## Fix

Wrap the `gs.init()` call in `env_gathering.py` with the same guard:

```python
# Before
gs.init(seed=0, precision="64", logging_level="error", backend=gs.gpu, performance_mode=True)

# After
if not gs._initialized:
    gs.init(seed=0, precision="64", logging_level="error", backend=gs.gpu, performance_mode=True)
```

This is a one-line change that aligns `env_gathering.py` with all other envs in the benchmark.

## Context

First noted in #1. Extracted here as a standalone fix per maintainer feedback.
